### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/Fritz-Fandango/sitka-my-app/security/code-scanning/1](https://github.com/Fritz-Fandango/sitka-my-app/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block to restrict the workflow's GITHUB_TOKEN permissions to the minimum necessary. In this case, since the workflow only analyzes code and does not require any write actions (like creating issues/pull requests or uploading artifacts with elevated permissions), the minimal starting point is `contents: read`. This can be set at the job level (inside the `analyze:` job) or at the workflow root (applies to all jobs in the workflow). Since there is only one job in this workflow, either approach suffices; however, adding it at the job level makes the edit minimally invasive and clearly associated with the analyzed job. The `permissions` key should be placed at the same indentation as `runs-on:` under the `analyze:` job (line 26). No other methods, imports, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
